### PR TITLE
feat: Added loading for charts

### DIFF
--- a/src/components/charts.py
+++ b/src/components/charts.py
@@ -3,13 +3,14 @@ import dash_bootstrap_components as dbc
 import dash_vega_components as dvc
 
 loading_color = "#008080"
+loading_type = "dot"
 
 map_chart = dbc.Card([
     dbc.CardHeader(html.H5('Map Chart', style={'fontWeight': 'bold'})),
     dbc.CardBody(
          dcc.Loading(  # Add loading spinner
             id="loading-map",
-            type="circle",
+            type=loading_type,
             color=loading_color,
             children=[
                 dvc.Vega(id='map_chart', spec={})
@@ -25,7 +26,7 @@ timeseries_chart = dbc.Card([
     dbc.CardBody([
         dcc.Loading(
             id="loading-timeseries",
-            type="circle",
+            type=loading_type,
             color=loading_color,
             children=[dvc.Vega(id='timeseries_chart', spec={})]
         )
@@ -37,7 +38,7 @@ bar_chart = dbc.Card([
     dbc.CardBody([
         dcc.Loading(
             id="loading-bar",
-            type="circle",
+            type=loading_type,
             color=loading_color,
             children=[dvc.Vega(id='bar_chart', spec={})]
         )

--- a/src/components/charts.py
+++ b/src/components/charts.py
@@ -1,11 +1,20 @@
+from dash import html, dcc
 import dash_bootstrap_components as dbc
-import dash_html_components as html
 import dash_vega_components as dvc
+
+loading_color = "#008080"
 
 map_chart = dbc.Card([
     dbc.CardHeader(html.H5('Map Chart', style={'fontWeight': 'bold'})),
     dbc.CardBody(
-        dvc.Vega(id='map_chart', spec={}),
+         dcc.Loading(  # Add loading spinner
+            id="loading-map",
+            type="circle",
+            color=loading_color,
+            children=[
+                dvc.Vega(id='map_chart', spec={})
+            ]
+        ),
         className="d-flex justify-content-center w-100",
         style={"height": "100%"}
     ) 
@@ -14,13 +23,23 @@ map_chart = dbc.Card([
 timeseries_chart = dbc.Card([
     dbc.CardHeader(html.H5('Time Series Chart', style={'fontWeight': 'bold'})),
     dbc.CardBody([
-        dvc.Vega(id='timeseries_chart', spec={})
+        dcc.Loading(
+            id="loading-timeseries",
+            type="circle",
+            color=loading_color,
+            children=[dvc.Vega(id='timeseries_chart', spec={})]
+        )
     ])    
 ])
     
 bar_chart = dbc.Card([
     dbc.CardHeader(html.H5('Bar Chart', style={'fontWeight': 'bold'})),
     dbc.CardBody([
-        dvc.Vega(id='bar_chart', spec={})
+        dcc.Loading(
+            id="loading-bar",
+            type="circle",
+            color=loading_color,
+            children=[dvc.Vega(id='bar_chart', spec={})]
+        )
     ])
 ])

--- a/src/components/summary.py
+++ b/src/components/summary.py
@@ -46,5 +46,6 @@ summary = dcc.Loading(
         ],
         style={'paddingBottom': '1rem', "paddingTop": "0.625rem"}
     ),
-    type="cube", fullscreen=False, color="white"
+    type="circle", 
+    color="#008080"
 )

--- a/src/components/summary.py
+++ b/src/components/summary.py
@@ -45,6 +45,6 @@ summary = dcc.Loading(
         ],
         style={'paddingBottom': '1rem', "paddingTop": "0.625rem"}
     ),
-    type="circle", 
+    type="dot", 
     color="#008080"
 )


### PR DESCRIPTION
There are a few loading options: dot, cube, circle, default 
<img width="1196" alt="Screen Shot 2025-03-06 at 9 40 53 PM" src="https://github.com/user-attachments/assets/f8f5c066-74be-45e8-8991-c8ba16f8e79b" />  


I'm using the circle with our color. Feel free to let me know if we want other loading options or other colors.
<img width="1141" alt="Screen Shot 2025-03-06 at 9 44 52 PM" src="https://github.com/user-attachments/assets/75b6c828-6432-44a1-97f6-b164672f0ebf" />

Updated: changed to use dot
<img width="1157" alt="Screen Shot 2025-03-06 at 10 40 01 PM" src="https://github.com/user-attachments/assets/8373db99-c30d-4ff4-bfb8-5aaa7d727f6c" />
