### PR TITLE
fix: Added chart name in the card header + layout fixes

### DIFF
--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -14,9 +14,15 @@ def create_map_chart(filtered_data, spend_metric, spend_metric_label):
               hover_data = {'name' : True, spend_metric: ':.2f', 'LOCATION': False},
               color_continuous_scale="tealrose"
             )
+    
+    map_chart.update_coloraxes(reversescale=True)
     map_chart.update_layout(
-        width=1000,
-        coloraxis_colorbar=dict(title=spend_metric_label)
+        autosize=True,
+        coloraxis_colorbar=dict(title=spend_metric_label,
+                                thickness=10,
+                                len=0.5,
+                                x=1),
+        margin=dict(l=0, r=0, t=10, b=0)
     )
     
     map_chart.update_geos(showframe=False, lataxis=dict(range=[-60, 90]))
@@ -40,9 +46,7 @@ def create_time_chart(filtered_data, spend_metric, spend_metric_label, start_yea
         tooltip=['name', spend_metric]
     )
 
-    timeseries_chart = (line + points).properties(
-        title= f'{spend_metric_label} by Country ({start_year_select} to {end_year_select})'
-    )
+    timeseries_chart = (line + points)
     return timeseries_chart
 
 def create_bar_chart(avg_data, spend_metric, spend_metric_label):
@@ -53,8 +57,6 @@ def create_bar_chart(avg_data, spend_metric, spend_metric_label):
         x=alt.X(f'mean({spend_metric}):Q', title="Total Spend (USD)"),
         y=alt.Y('name:N', title="Country", sort='x'),  
         tooltip=['name', f'mean({spend_metric})']
-    ).properties(
-        title=f"Average {spend_metric_label} by Country"
     )
     return bar_chart
 
@@ -63,6 +65,9 @@ def charts_callback(data):
         Output('map_chart', 'figure'),
         Output('timeseries_chart', 'spec'),
         Output('bar_chart', 'spec'),
+        Output('map_title', 'children'),
+        Output('timeseries_title', 'children'),
+        Output('bar_title', 'children'),
         Input('country_select', 'value'),
         Input('start_year_select', 'value'),
         Input('end_year_select', 'value'),
@@ -84,11 +89,13 @@ def charts_callback(data):
         alt.data_transformers.enable('vegafusion')
 
         # Map Plot (Daria)
+        map_title = f'{spend_metric_label} by Country'
         map_chart = create_map_chart(filtered_data, 
                                     spend_metric, 
                                     spend_metric_label)
 
         # Time Series Chart (Jason)
+        timeseries_title = f'{spend_metric_label} by Country ({start_year_select} to {end_year_select})'
         timeseries_chart = create_time_chart(
             filtered_data, 
             spend_metric, 
@@ -98,10 +105,11 @@ def charts_callback(data):
         )
 
         # Bar Chart (Celine)
+        bar_title = f'Average {spend_metric_label} by Country'
         bar_chart = create_bar_chart(
             avg_data, 
             spend_metric, 
             spend_metric_label
         )
 
-        return map_chart, timeseries_chart.to_dict(format="vega"), bar_chart.to_dict(format="vega")
+        return map_chart, timeseries_chart.to_dict(format="vega"), bar_chart.to_dict(format="vega"),map_title, timeseries_title, bar_title

--- a/src/callbacks/summary.py
+++ b/src/callbacks/summary.py
@@ -31,9 +31,9 @@ def summary_callback(data):
             growth = ((df.iloc[-1] - df.iloc[0]) / df.iloc[0]) * 100
             
             if growth > 0:
-                return f"+{growth:.1f}% Growth", {"color": "green", "textAlign": "center"}
+                return f"+{growth:.1f}% Growth", {"color": "green", "textAlign": "center", "marginBottom": "1px"}
             else:
-                return f"{growth:.1f}% Growth", {"color": "red", "textAlign": "center"}
+                return f"{growth:.1f}% Growth", {"color": "red", "textAlign": "center", "marginBottom": "1px"}
 
         # Compute summary stats
         gdp_value = f"{filtered_data['PC_GDP'].mean():.2f}%"

--- a/src/components/charts.py
+++ b/src/components/charts.py
@@ -6,22 +6,22 @@ loading_color = "#008080"
 loading_type = "dot"
 
 map_chart = dbc.Card([
-    dbc.CardHeader(html.H5('Map Chart', style={'fontWeight': 'bold'})),
+    dbc.CardHeader(html.H6(id='map_title', style={'fontWeight': 'bold', "margin": "2px", "padding": "0px"})),
     dbc.CardBody(
          dcc.Loading(  # Add loading spinner
             id="loading-map",
             type=loading_type,
             color=loading_color,
             children=[
-                dcc.Graph(id='map_chart')
+                dcc.Graph(id='map_chart', style = {"height": "100%", "width": "100%", "padding": "0px", "overflow": "hidden"}) 
             ]
         ),
-        style={"height": "100%", "width":"100%"}
+        style={"height": "350px", "padding": "0px", "overflow": "hidden"}
     ) 
-], style={"width": "100%", "height": "100%"})
+], style={"width": "100%", "height": "450px", "padding": "0px", "overflow": "hidden"})
 
 timeseries_chart = dbc.Card([
-    dbc.CardHeader(html.H5('Time Series Chart', style={'fontWeight': 'bold'})),
+    dbc.CardHeader(html.H6(id='timeseries_title', style={'fontWeight': 'bold', "margin": "2px"})),
     dbc.CardBody([
         dcc.Loading(
             id="loading-timeseries",
@@ -33,7 +33,7 @@ timeseries_chart = dbc.Card([
 ])
     
 bar_chart = dbc.Card([
-    dbc.CardHeader(html.H5('Bar Chart', style={'fontWeight': 'bold'})),
+    dbc.CardHeader(html.H6(id='bar_title', style={'fontWeight': 'bold', "margin": "2px"})),
     dbc.CardBody([
         dcc.Loading(
             id="loading-bar",

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -19,7 +19,6 @@ def create_sidebar(locations, times, min_year, max_year):
             ),
             html.Div(id="warning", style={"color": "red", "marginTop": "10px"}),  # Warning message
             html.Br(),
-            html.Br(),
 
             html.H5('Year', style={'fontWeight': 'bold'}),
             html.P('From', style={'marginBottom': '0.375rem'}),
@@ -36,7 +35,6 @@ def create_sidebar(locations, times, min_year, max_year):
                 value=max_year,  # Default end by the maximum year
                 clearable=False
             ),
-            html.Br(),
             html.Br(),
             
             html.H5('Spend Metrics', style={'fontWeight': 'bold'}),

--- a/src/components/summary.py
+++ b/src/components/summary.py
@@ -2,10 +2,13 @@ from dash import html, dcc
 import dash_bootstrap_components as dbc
 
 card_style = {
-    "height": "140px",
+    "height": "70px",
     "backgroundColor": "#e6e6e6",  # Light gray background 
     "borderRadius": "10px",  # Rounded corners
-    "padding": "5px"
+    "padding": "0px",
+    "alignItems": "center",  # Align everything vertically
+    "justifyContent": "center",  # Center content inside
+    "textAlign": "center"
 }
 
 summary = dcc.Loading(
@@ -14,36 +17,36 @@ summary = dcc.Loading(
             dbc.Col(dbc.Card([
                 dbc.CardBody([
                     html.H6("Avg % GDP", style={"textAlign": "center"}),
-                    html.H2(id="gdp-value", style={"fontWeight": "bold", "textAlign": "center"}),  
+                    html.H3(id="gdp-value", style={"fontWeight": "bold", "textAlign": "center"}),  
                     html.P(id="gdp-growth", style={"color": "green", "fontSize": "14px"})  
-                ])
+                ], style={"padding": "5px"})
             ], id='card-gdp', style=card_style), md=3),
 
             dbc.Col(dbc.Card([
                 dbc.CardBody([
                     html.H6("Avg % of Health Spending", style={"textAlign": "center"}),
-                    html.H2(id="health-value", style={"fontWeight": "bold", "textAlign": "center"}),
+                    html.H3(id="health-value", style={"fontWeight": "bold", "textAlign": "center"}),
                     html.P(id="health-growth", style={"color": "green", "fontSize": "14px"})
-                ])
+                ], style={"padding": "5px"})
             ], id= 'card-health', style=card_style), md=3),
 
             dbc.Col(dbc.Card([
                 dbc.CardBody([
                     html.H6("Avg Spend per Capita (USD)", style={"textAlign": "center"}),
-                    html.H2(id="capita-value", style={"fontWeight": "bold", "textAlign": "center"}),
+                    html.H3(id="capita-value", style={"fontWeight": "bold", "textAlign": "center"}),
                     html.P(id="capita-growth", style={"color": "green", "fontSize": "14px"})
-                ])
+                ], style={"padding": "5px"})
             ], id='card-capita', style=card_style), md=3),
 
             dbc.Col(dbc.Card([
                 dbc.CardBody([
                     html.H6("Avg Total Spend (USD B)", style={"textAlign": "center"}),
-                    html.H2(id="total-value", style={"fontWeight": "bold", "textAlign": "center"}),
+                    html.H3(id="total-value", style={"fontWeight": "bold", "textAlign": "center"}),
                     html.P(id="total-growth", style={"color": "green", "fontSize": "14px"})
-                ])
+                ], style={"padding": "5px"})
             ], id='card-total', style=card_style), md=3),
         ],
-        style={'paddingBottom': '1rem', "paddingTop": "0.625rem"}
+        style={'paddingBottom': '1rem', "paddingTop": "0.5rem"}
     ),
     type="dot", 
     color="#008080"


### PR DESCRIPTION
- Added chart name in the card head
- Flipped the map chart color scale (large values = green / small values = red)
- Reduce card summary padding to make them more compact
- Reduce card header padding to make them more compact
- Reduce font size of metric numbers in the summary card
- Reduce font size of chart titles
- Removed the chart titles from the altair plots
